### PR TITLE
faster loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+# custom dont-upload files
+custom_tests/*
+
 # C extensions
 *.so
 

--- a/se3_transformer_pytorch/spherical_harmonics.py
+++ b/se3_transformer_pytorch/spherical_harmonics.py
@@ -106,7 +106,7 @@ def get_spherical_harmonics_element(l, m, theta, phi):
     return Y
 
 def get_spherical_harmonics(l, theta, phi):
-    """Tesseral harmonic with Condon-Shortley phase.
+    """ Tesseral harmonic with Condon-Shortley phase.
 
     The Tesseral spherical harmonics are also known as the real spherical
     harmonics.
@@ -118,8 +118,6 @@ def get_spherical_harmonics(l, theta, phi):
     Returns:
         tensor of shape [*theta.shape, 2*l+1]
     """
-    results = []
-    for m in range(-l, l+1):
-        el = get_spherical_harmonics_element(l, m, theta, phi)
-        results.append(el)
-    return torch.stack(results, dim = -1)
+    return torch.stack([ get_spherical_harmonics_element(l, m, theta, phi) \
+                         for m in range(-l, l+1) ],
+                        dim = -1)


### PR DESCRIPTION
My small grain on sand for this project ;) : at least don't deal with python appends which are 2x slower than list comprehension.

If this is of any help, here are some considerations (there might be misunderstandings on my side due to the decorators and so on):
* i have my reservations on the utility of the line 62 in `utils.py`
* would't make more sense to start the `for` i modified (line 122 of `utils.py`) in reverse order, then use the cached calculations for the `lpmv()` ?
* same case (loop in reverse order) for the `for` in line 148 of `basis.py`?
* if using the `scipy.special.poch` (which can deal with np arrays) instead of the custom `pochhammer` implementation, all operations inside `get_spherical_harmonics_element` are vectorizeable but the `lpmv` function call. 
    * My sense is that the `lpmv`, `get_spherical_harmonics_element` and `get_spherical_harmonics` could be all wrapped in a single function (lower reusability / extension... so maybe doing the inverse loop order and caching is enough).
