### PR TITLE
denoise.py bugfix 

### DIFF
--- a/denoise.py
+++ b/denoise.py
@@ -33,7 +33,8 @@ transformer = SE3Transformer(
     num_neighbors = 0,
     attend_sparse_neighbors = True,
     num_adj_degrees = 2,
-    adj_dim = 4
+    adj_dim = 4,
+    num_degrees=2,
 )
 
 data = scn.load(


### PR DESCRIPTION
Fixes issue related to the constructor

```
Traceback (most recent call last):
  File "/home/jcastellanos/projects/se3-transformer-pytorch/denoise.py", line 22, in <module>
    transformer = SE3Transformer(
  File "/home/jcastellanos/projects/se3-transformer-pytorch/se3_transformer_pytorch/se3_transformer_pytorch.py", line 1072, in __init__
    self.num_degrees = num_degrees if exists(num_degrees) else (max(hidden_fiber_dict.keys()) + 1)
AttributeError: 'NoneType' object has no attribute 'keys'
```